### PR TITLE
Fix home page color not applying to blank new windows

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -189,7 +189,9 @@ async function getTabMeta(
 	} catch {
 		console.info("Could not connect to", url);
 
-		if (protocol === "about:") {
+		if (await isHomePage(href)) {
+			return { colour: browserColour.HOME, reason: "HOME_PAGE" };
+		} else if (protocol === "about:") {
 			return await getAboutPageMeta(windowId, href, pathname, title);
 		} else if (protocol === "moz-extension:") {
 			return await getWebExtPageMeta(webExtId);
@@ -383,6 +385,18 @@ async function getWebExtPageMeta(webExtId?: string): Promise<MetaQueryResult> {
 	}
 }
 
+/** Applies the home page colour to a window as soon as it is created */
+function paintNewWindow(windowId: number): void {
+	if (!pref.isReady || pref.compatibilityMode) return;
+	const { colour, scheme } = browserColour.HOME.contrastCorrection(
+		cache.scheme,
+		pref.allowDarkLight,
+		pref.minContrast_light,
+		pref.minContrast_dark,
+	);
+	void applyTheme(windowId, colour, scheme);
+}
+
 /** Applies the colour to the browser frame. */
 function setFrameColour(
 	tab: Browser.tabs.Tab,
@@ -560,6 +574,7 @@ async function applyTheme(
 }
 
 export default defineBackground(() => {
+	addWindowCreatedListener(paintNewWindow);
 	pref.initialise().then(run);
 	pref.addOnChangeListener(run);
 	addSchemeChangeListener(run);

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -101,6 +101,15 @@ export function addTabChangeListener(listener: () => void): void {
 	browser.windows?.onBoundsChanged?.addListener(listener);
 }
 
+/** Registers a listener for window creation. */
+export function addWindowCreatedListener(
+	listener: (windowId: number) => void,
+): void {
+	browser.windows?.onCreated?.addListener((window) => {
+		if (window.id !== undefined) listener(window.id);
+	});
+}
+
 /** Checks whether the tab's window is incognito. */
 export async function isWindowIncognito(windowId: number): Promise<boolean> {
 	try {
@@ -116,6 +125,22 @@ export async function getActiveWindowId(): Promise<number | undefined> {
 		(await browser.tabs?.query({ active: true, currentWindow: true }))?.[0]
 			?.windowId ?? (await browser.windows?.getLastFocused())?.id
 	);
+}
+
+/** Checks whether a URL is one Firefox opens for the home page or for new tabs.*/
+export async function isHomePage(href: string): Promise<boolean> {
+	if (href === "about:blank") return true;
+	try {
+		const settings = browser.browserSettings;
+		const homepage = (await settings?.homepageOverride?.get({}))?.value;
+		const newTabPage = (await settings?.newTabPageOverride?.get({}))?.value;
+		return [
+			...(typeof homepage === "string" ? homepage.split("|") : []),
+			...(typeof newTabPage === "string" ? [newTabPage] : []),
+		].some((candidate) => candidate.trim() === href);
+	} catch {
+		return false;
+	}
 }
 
 /** Retrieves all active and fully loaded tabs. */


### PR DESCRIPTION
# Fix home page color not applying to new windows

With "Homepage and new windows" or "New tabs" set to **Blank Page**, the configured home page color is never used. The tab bar renders `#282828` in dark mode regardless of what the setting says

Selecting Blank Page makes Firefox load `chrome://browser/content/blanktab.html`. It is not an `about:` page, so in `getTabMeta` it never reaches the branch that resolves the home page colour:

```js
} else if (protocol === "about:") {
    return await getAboutPageMeta(windowId, href, pathname, title);  // HOME lives here
} else if (sourcePageProtocol.includes(protocol)) {                  // "chrome:" matches
    return getSourcePageMeta(protocol, href);
}
```
getSourcePageMeta only special cases plaintext, .png/.jpg and .svg, so a .html chrome page falls through to its final else and resolves to SYSTEM.

HOME is reachable only from getAboutPageMeta, so for anyone using Blank Page the "Home page color" setting has no effect at all.

## Reproduction

1. Settings > Home > set both dropdowns to Blank Page
2. ATBC options > set a distinctive Home page colour for the active scheme
3. Open a new window (Ctrl + N)

The tab bar shows #282828, not the color that was set