### PR TITLE
Add Azerbaijani translation

### DIFF
--- a/amo/amo-az.md
+++ b/amo/amo-az.md
@@ -1,0 +1,94 @@
+**Bu əlavə nə edir?**
+
+Bu əlavə Firefox temasını baxdığınız veb saytın görünüşünə uyğun olaraq dinamik şəkildə tənzimləyir. Davranış macOS-dakı Safari brauzerinin tab panelini rəngləmə imkanına bənzəyir.
+
+**Yaxşı işlədiyi əlavələr**
+
+- [Dark Reader](https://addons.mozilla.org/firefox/addon/darkreader/)
+- [Stylus](https://addons.mozilla.org/firefox/addon/styl-us/)
+- [Dark Mode Website Switcher](https://addons.mozilla.org/firefox/addon/dark-mode-website-switcher/)
+
+**Uyğun gəlmədiyi əlavələr**
+
+- [Adaptive Theme Creator](https://addons.mozilla.org/firefox/addon/adaptive-theme-creator/)
+- [Chameleon Dynamic Theme](https://addons.mozilla.org/firefox/addon/chameleon-dynamic-theme-fixed/)
+- [VivaldiFox](https://addons.mozilla.org/firefox/addon/vivaldifox/)
+- [Envify](https://addons.mozilla.org/firefox/addon/envify/)
+- Firefox temasını dəyişdirən istənilən digər əlavə
+
+**Alət panelinin altındakı kölgəni silmək**
+
+Veb məzmunun brauzerin alət panelinə saldığı nazik kölgəni silmək üçün Parametrlərə (`about:preferences`) keçin və “Brauzerin quruluşu” bölməsində “Yan paneli göstər” seçimini söndürün. Bunun əvəzinə aşağıdakı kodu CSS temanıza da əlavə edə bilərsiniz:
+
+> `#tabbrowser-tabbox, .browserContainer {`
+
+> > `box-shadow: none !important;`
+
+> `}`
+
+**Rəng keçidlərini fərdiləşdirmək**
+
+Firefox tab panelinin rəng dəyişikliklərinə öz daxili keçid effektini tətbiq edir. Bu davranışı söndürmək və Adaptive Tab Bar Colour (ATBC) əlavəsinin rəngləri dərhal yeniləməsinə imkan vermək üçün aşağıdakı kodu CSS temanıza əlavə edin:
+
+> `:root {`
+
+> > ```
+> > --ext-theme-background-transition: none !important;
+> > --inactive-window-transition: none !important;
+> > ```
+
+> `}`
+
+Digər tərəfdən, tab paneli üçün yumşaq rəng keçidlərini üstün tuta bilərsiniz. Texniki məhdudiyyətlərə görə bu, daxili şəkildə dəstəklənmir, ona görə aşağıdakı kodu CSS temanıza əlavə edin ([@Moarram](https://github.com/Moarram/) sayəsində):
+
+> `#navigator-toolbox, #TabsToolbar, #nav-bar, #PersonalToolbar, #sidebar-box, .tab-background, .urlbar-background, findbar, body {`
+
+> > `transition:`
+
+> > > ```
+> > > background-color 0.5s cubic-bezier(0, 0, 0, 1) !important,
+> > > border-color 0.5s cubic-bezier(0, 0, 0, 1) !important,
+> > > outline 0.5s cubic-bezier(0, 0, 0, 1) !important;
+> > > ```
+
+> `}`
+
+Sidebery interfeysində yumşaq rəng keçidlərini aktivləşdirmək üçün aşağıdakı kodu Sidebery Style Editor bölməsinə əlavə edin ([@MaxHasBeenUsed](https://github.com/MaxHasBeenUsed/) sayəsində):
+
+> `.Sidebar, .bottom-space {`
+
+> > `transition: background-color 0.5s cubic-bezier(0, 0, 0, 1) !important;`
+
+> `}`
+
+**Kontekst menyularında uyğunlaşan tema**
+
+Uyğunlaşan temanı kontekst menyularına tətbiq etmək üçün aşağıdakı kodu CSS temanıza əlavə edin:
+
+> `:is(menupopup, panel):where(:not([type="arrow"])) {`
+
+> > ```
+> > --panel-background-color: unset !important;
+> > --panel-border-color: unset !important;
+> > ```
+
+> `}`
+
+Bundan başqa, `about:config` səhifəsini açıb aşağıdakı tərcihləri `false` etməklə sistemin öz kontekst menyuları söndürülməlidir:
+
+- `widget.gtk.native-context-menus` (Linux)
+- `widget.macos.native-context-menus` (macOS)
+
+**Üçüncü tərəf CSS temaları ilə uyğunluq**
+
+Üçüncü tərəf CSS teması Firefox-un standart rəng dəyişənlərindən (məsələn, tab panelinin rəngi üçün `--lwt-accent-color`) istifadə etdiyi müddətcə Adaptive Tab Bar Colour (ATBC) ilə işləyir. [Bu](https://github.com/easonwong-de/Firefox-Adaptive-Sur-Theme), ATBC ilə uyğun CSS temasının nümunəsidir.
+
+**GTK teması ilə Linux-da başlıq sətri düymələri**
+
+Firefox-un başlıq sətri düymələri Windows üslubuna qayıda bilər. Bunun qarşısını almaq üçün “Qabaqcıl tərcihlər” (`about:config`) səhifəsini açın və `widget.gtk.non-native-titlebar-buttons.enabled` dəyərini `false` edin. ([@anselstetter](https://github.com/anselstetter/) sayəsində)
+
+**Təhlükəsizlik xatırlatması**
+
+Zərərli veb interfeyslərdən ehtiyatlı olun. Brauzerin interfeysi ilə veb səhifənin interfeysini ayırd etmək vacibdir. Ətraflı məlumat üçün [The Line of Death](https://textslashplain.com/2017/01/14/the-line-of-death/) yazısına baxın. ([u/KazaHesto](https://www.reddit.com/user/KazaHesto/) sayəsində)
+
+Bu layihəni GitHub-da ulduzlamaqdan çəkinməyin: [https://github.com/atbc-org/Adaptive-Tab-Bar-Colour](https://github.com/atbc-org/Adaptive-Tab-Bar-Colour)

--- a/src/locales/az.yaml
+++ b/src/locales/az.yaml
@@ -98,8 +98,8 @@ themeColourNotFound: Tema rəngi tapılmadı, rəng veb səhifədən seçilir
 toolbar: Alət paneli
 urlBar: URL sətri
 urlDomainOrRegex: URL/regex/joker/domen
-use: İstifadə et
-useIgnoreThemeColour: tema rəngini istifadə et/nəzərə alma
+use: İşlət
+useIgnoreThemeColour: tema rəngini işlət/nəzərə alma
 usingColourForHomePage: Əsas səhifə üçün rəng işlədilir
 usingColourForJSONViewer: JSON göstəricisi üçün rəng işlədilir
 usingColourForPDFViewer: PDF göstəricisi üçün rəng işlədilir

--- a/src/locales/az.yaml
+++ b/src/locales/az.yaml
@@ -1,0 +1,123 @@
+addANewRule: Yeni qayda əlavə et
+addonNotFound: Əlavə tapılmadı
+advanced: Qabaqcıl
+allowDarkTabBar: Tünd tab panelinə icazə ver
+allowDarkTabBarTooltip:
+    Tab panelinin tünd rəng işlətməsinə icazə verir (tünd tab panelində açıq
+    mətn).
+allowLightTabBar: Açıq tab panelinə icazə ver
+allowLightTabBarTooltip:
+    Tab panelinin parlaq rəng işlətməsinə icazə verir (açıq tab panelində tünd
+    mətn).
+anyCSSColour: İstənilən format
+background: Fon
+backgroundOnFocus: Fokusda fon
+backupAndReset: Ehtiyat nüsxə və sıfırlama
+border: Haşiyə
+colourIsAdjusted: Minimum kontrastı təmin etmək üçün ilkin rəng tənzimlənib
+compatibilityMode: Uyğunluq rejimi
+compatibilityModeTooltip:
+    Tema API-si əvəzinə veb saytın “theme-color” metaməlumatı dəyişdirilir.
+    Dəstəkləyən brauzerlər tab panelinin rəngini buna uyğun tənzimləyir.
+confirmResetAll: Bütün parametrləri sıfırlamaq istədiyinizə əminsiniz?
+confirmResetThemeBuilder: Tema qurucusunu sıfırlamaq istədiyinizə əminsiniz?
+couldNotFindElement: "Uyğun gələn HTML elementi tapılmadı: "
+couldNotFindElementEnd: ", əvəzinə rəng veb səhifədən seçildi"
+delete: Sil
+deleteRule: Qaydanı sil
+dynamicColourUpdate: Dinamik rəng yeniləməsi
+dynamicModeTooltip:
+    Veb səhifə daxilində gəzərkən tab panelinin rəngi yenilənməyə davam edir.
+errorOccured: Xəta baş verdi, ehtiyat rəng işlədilir
+errorOccuredLocatingElement:
+    "Uyğun gələn HTML elementi axtarılarkən xəta baş verdi: "
+errorOccuredLocatingElementEnd: ", əvəzinə rəng veb səhifədən seçilir"
+exportSettings: Parametrləri ixrac et
+extensionDescription:
+    Firefox temasının rəngini veb saytın görünüşünə uyğunlaşdırır.
+extensionName: Adaptive Tab Bar Colour
+fallbackColourDark: "Ehtiyat rəng: tünd"
+fallbackColourLight: "Ehtiyat rəng: açıq"
+frame: Çərçivə
+homepageColourDark: "Əsas səhifə rəngi: tünd"
+homepageColourLight: "Əsas səhifə rəngi: açıq"
+ifVerticalTabsAreEnabled:
+    “Şaquli tablar” aktivdirsə, sıfırdan fərqli istənilən dəyər pəncərə
+    idarəetmə düymələrinin üstündə boşluq yarada və onlara çatmağı çətinləşdirə
+    bilər.
+ignore: Nəzərə alma
+ignoreDesignatedThemeColour: Veb saytın tema rəngini nəzərə alma
+ignoreDesignatedThemeColourTooltip:
+    Bəzi veb saytlar tema rəngini özləri təqdim edir. Bu rəngləri nəzərə almamaq
+    üçün bu seçimi aktivləşdirin.
+importFailed:
+    Parametrləri idxal etmək alınmadı. Zəhmət olmasa yenidən cəhd edin.
+importSettings: Parametrləri idxal et
+inDarkMode: Tünd rejimdə
+inLightMode: Açıq rejimdə
+loading: Yüklənir…
+minimumContrast: Minimum kontrast
+minimumContrastTooltip:
+    Tab paneli ilə mətn arasındakı minimum kontrast nisbətini təyin edin. Nisbət
+    ödənilmirsə tab panelinin rəngi tənzimlənəcək.
+moreSettings: Daha çox parametr
+moreSettingsTooltip: Seçimlər səhifəsini aç
+no: Xeyr
+novaUi: Nova UI rənglərini işlət
+novaUiTooltip: Firefox Nova UI işlədirsə aktivləşdirin.
+overwriteAccentColour: Vurğu rəngini əvəz et
+overwriteAccentColourTooltip:
+    URL sətri və alət paneli düymələri üçün sisteminizin rəngi əvəzinə fərdi
+    vurğu rəngi işlədin.
+pageIsProtected: Bu səhifə brauzer tərəfindən qorunur
+pickColourFromElement: elementdən rəng seç
+popUp: Açılan pəncərə
+querySelector: Sorğu seçicisi
+reportAnIssue: Problem bildir / təklif göndər / bu əlavəni tərcümə et
+reset: Sıfırla
+resetAll: Hamısını sıfırla
+resetAllSettings: Bütün parametrləri sıfırla
+ruleAppliedInBothMode: Qayda həm açıq, həm də tünd rejimdə tətbiq olunacaq
+ruleAppliedInDarkMode: Qayda yalnız tünd rejimdə tətbiq olunacaq
+ruleAppliedInLightMode: Qayda yalnız açıq rejimdə tətbiq olunacaq
+ruleList: Qaydalar siyahısı
+ruleWillBeIgnored: Bu qayda nəzərə alınmayacaq
+selectedTab: Seçilmiş tab
+settingsAreExported: Parametrlər endirmələr qovluğunuza ixrac edildi.
+settingsAreImported: Parametrlər idxal edildi.
+sidebar: Yan panel
+specifyAColour: rəng təyin et
+system: Sistem
+tabBar: Tab paneli
+themeBuilder: Tema qurucusu
+themeColourIsIgnored: Veb saytın təyin etdiyi tema rəngi nəzərə alınmır
+themeColourIsUnignored:
+    Veb saytın təyin etdiyi tema rəngi standart olaraq nəzərə alınmasa da
+    işlədilir
+themeColourNotFound: Tema rəngi tapılmadı, rəng veb səhifədən seçilir
+toolbar: Alət paneli
+urlBar: URL sətri
+urlDomainOrRegex: URL/regex/joker/domen
+use: İstifadə et
+useIgnoreThemeColour: tema rəngini istifadə et/nəzərə alma
+usingColourForHomePage: Əsas səhifə üçün rəng işlədilir
+usingColourForJSONViewer: JSON göstəricisi üçün rəng işlədilir
+usingColourForPDFViewer: PDF göstəricisi üçün rəng işlədilir
+usingColourForPlainTextViewer: Sadə mətn göstəricisi üçün rəng işlədilir
+usingColourFromElement: "Rəng uyğun gələn HTML elementindən seçilir: "
+usingColourFromElementEnd: "\0"
+usingColourFromWebpage: Rəng veb səhifədən seçilir
+usingDefaultColourForAddon:
+    "Standart rəng bununla əlaqəli səhifələr üçün işlədilir: "
+usingDefaultColourForAddonEnd: "\0"
+usingFallbackColour: Heç bir rəng mövcud deyil, ehtiyat rəng işlədilir
+usingImageViewer: Şəkil göstəricisi üçün rəng işlədilir
+usingPresetColourForAddon:
+    "Hazır rəng bununla əlaqəli səhifələr üçün işlədilir: "
+usingPresetColourForAddonEnd: "\0"
+usingSpecifiedColour: Bu sayt üçün rəng parametrlərdə təyin edilib
+usingSpecifiedColourForAddon:
+    "Təyin edilmiş rəng bununla əlaqəli səhifələr üçün işlədilir: "
+usingSpecifiedColourForAddonEnd: "\0"
+usingThemeColour: Veb saytın təyin etdiyi tema rəngi işlədilir
+yes: Bəli


### PR DESCRIPTION
This PR adds an Azerbaijani (az) translation.

New file `src/locales/az.yaml`: 99 strings, all filled in, key order identical to `src/locales/en.yaml`. New file `amo/amo-az.md`: the store description, added because `.github/CONTRIBUTING.md` lists both files for a new locale. `extensionName` is kept as Adaptive Tab Bar Colour, as in the other locales. No other file changed: `@wxt-dev/i18n` reads every `src/locales/*.yaml` and `scripts/sync-amo.sh` loops over every `amo/amo-*.md`, so there is no locale list to register in.